### PR TITLE
feat: add pre-inscription form

### DIFF
--- a/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.customjs.js
+++ b/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.customjs.js
@@ -1,0 +1,75 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('start-form');
+  if (!form) return;
+
+  const api = {
+    async getChildren(accountId) {
+      try {
+        const resp = await fetch(`/api/children?accountid=${encodeURIComponent(accountId)}`);
+        if (!resp.ok) return [];
+        return await resp.json();
+      } catch {
+        return [];
+      }
+    },
+    async getParent2(accountId, parent1Email) {
+      try {
+        const url = `/api/parent2?accountid=${encodeURIComponent(accountId)}&email=${encodeURIComponent(parent1Email)}`;
+        const resp = await fetch(url);
+        if (!resp.ok) return null;
+        return await resp.json();
+      } catch {
+        return null;
+      }
+    }
+  };
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const accountId = document.getElementById('accountId').value.trim();
+    const parent1Email = document.getElementById('parent1Email').value.trim();
+
+    const url = await route(
+      { after: 'parent1', accountId, parent1Email },
+      api
+    );
+
+    window.location.href = url;
+  });
+});
+
+async function route(params, api) {
+  const accountId = params.accountId;
+  const parent1Email = params.parent1Email;
+
+  async function decideParent2() {
+    const parent2 = await api.getParent2(accountId, parent1Email);
+    if (parent2) {
+      return `/parent2/edit?parent2id=${parent2.contactid}`;
+    }
+    return `/parent2/create?accountid=${accountId}`;
+  }
+
+  if (params.after === 'parent1') {
+    const children = await api.getChildren(accountId);
+    if (!children || children.length === 0) {
+      return await decideParent2();
+    }
+    const [first, ...rest] = children;
+    const remaining = rest.map(c => c.contactid).join(',');
+    return `/eleve?eleveid=${first.contactid}&remaining=${remaining}`;
+  }
+
+  if (params.after === 'eleve') {
+    const remaining = (params.remaining || '')
+      .split(',')
+      .filter(Boolean);
+    if (remaining.length > 0) {
+      const [next, ...rest] = remaining;
+      return `/eleve?eleveid=${next}&remaining=${rest.join(',')}`;
+    }
+    return await decideParent2();
+  }
+
+  return '/';
+}

--- a/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.webpage.copy.html
+++ b/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.webpage.copy.html
@@ -1,0 +1,14 @@
+
+<form id="start-form">
+  <div>
+    <label for="accountId">Identifiant du compte</label>
+    <input type="text" id="accountId" required />
+  </div>
+  <div>
+    <label for="parent1Email">Email du Parent 1</label>
+    <input type="email" id="parent1Email" required />
+  </div>
+  <button type="submit">Commencer la pré‑inscription</button>
+</form>
+
+<script src="Accueil.fr-FR.customjs.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ecolemoser",
+  "version": "1.0.0",
+  "description": "Dématérialiser et automatiser la pré‑inscription dans Dataverse/Dynamics via Power Pages : Parent 1 authentifié, centralisation des données Élève/Parents, génération PDF, envoi signature (DocuSign/SignNow), suivi dans l’Opportunité, champs sensibles verrouillés.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,55 @@
+/**
+ * Routing utility for the Pré-inscription flow.
+ *
+ * The function implements the algorithm described in README.md. It inspects
+ * query parameters and uses the provided API helper to determine the next
+ * page to navigate to. The API helper is expected to expose two async
+ * functions:
+ *   - getChildren(accountId): resolves to an array of children contacts.
+ *   - getParent2(accountId, parent1Email): resolves to a contact or null.
+ *
+ * The function returns the URL (path + query string) of the next step.
+ *
+ * @param {Object} params - query string parameters from the current request.
+ * @param {Object} api - API helper with getChildren and getParent2 functions.
+ * @returns {Promise<string>} next route URL
+ */
+async function route(params, api) {
+  const accountId = params.accountId;
+  const parent1Email = params.parent1Email;
+
+  async function decideParent2() {
+    const parent2 = await api.getParent2(accountId, parent1Email);
+    if (parent2) {
+      return `/parent2/edit?parent2id=${parent2.contactid}`;
+    }
+    return `/parent2/create?accountid=${accountId}`;
+  }
+
+  if (params.after === 'parent1') {
+    const children = await api.getChildren(accountId);
+    if (!children || children.length === 0) {
+      return decideParent2();
+    }
+    const [first, ...rest] = children;
+    const remaining = rest.map(c => c.contactid).join(',');
+    return `/eleve?eleveid=${first.contactid}&remaining=${remaining}`;
+  }
+
+  if (params.after === 'eleve') {
+    const remaining = (params.remaining || '')
+      .split(',')
+      .filter(Boolean);
+    if (remaining.length > 0) {
+      const [next, ...rest] = remaining;
+      return `/eleve?eleveid=${next}&remaining=${rest.join(',')}`;
+    }
+    return decideParent2();
+  }
+
+  // Default: if no routing info, stay on current page
+  return '/';
+}
+
+module.exports = { route };
+

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,0 +1,63 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { route } = require('../src/router');
+
+let api;
+
+beforeEach(() => {
+  api = {
+    getChildren: async () => [],
+    getParent2: async () => null,
+  };
+});
+
+test('zero children leads to parent2 creation', async () => {
+  api.getChildren = async () => [];
+  api.getParent2 = async () => null;
+
+  const url = await route(
+    { after: 'parent1', accountId: 'A1', parent1Email: 'p1@example.com' },
+    api
+  );
+
+  assert.equal(url, '/parent2/create?accountid=A1');
+});
+
+test('multiple children routes to first child with remaining list', async () => {
+  api.getChildren = async () => [
+    { contactid: 'c1' },
+    { contactid: 'c2' },
+    { contactid: 'c3' },
+  ];
+
+  const url = await route(
+    { after: 'parent1', accountId: 'A1', parent1Email: 'p1@example.com' },
+    api
+  );
+
+  assert.equal(url, '/eleve?eleveid=c1&remaining=c2,c3');
+});
+
+test('existing parent2 routes to edit step', async () => {
+  api.getChildren = async () => [];
+  api.getParent2 = async () => ({ contactid: 'p2' });
+
+  const url = await route(
+    { after: 'parent1', accountId: 'A1', parent1Email: 'p1@example.com' },
+    api
+  );
+
+  assert.equal(url, '/parent2/edit?parent2id=p2');
+});
+
+test('parent2 creation after children loop completes', async () => {
+  api.getParent2 = async () => null;
+
+  const url = await route(
+    { after: 'eleve', accountId: 'A1', parent1Email: 'p1@example.com', remaining: '' },
+    api
+  );
+
+  assert.equal(url, '/parent2/create?accountid=A1');
+});
+


### PR DESCRIPTION
## Summary
- create Accueil page form for account ID and parent1 email
- add client-side router using API calls for child/parent flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1a8677588330b98e8a19437435aa