### PR TITLE
Auto-fill account and email for pre-inscription routing

### DIFF
--- a/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.customjs.js
+++ b/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.customjs.js
@@ -1,6 +1,7 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const form = document.getElementById('start-form');
-  if (!form) return;
+document.addEventListener('DOMContentLoaded', async () => {
+  const accountIdField = document.getElementById('accountId');
+  const parent1EmailField = document.getElementById('parent1Email');
+  if (!accountIdField || !parent1EmailField) return;
 
   const api = {
     async getChildren(accountId) {
@@ -43,19 +44,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    const accountId = document.getElementById('accountId').value.trim();
-    const parent1Email = document.getElementById('parent1Email').value.trim();
+  const accountId = accountIdField.value.trim();
+  const parent1Email = parent1EmailField.value.trim();
 
-    const url = await route(
-      { after: 'parent1', accountId, parent1Email },
-      api
-    );
-    console.log('[Pré-inscription] redirecting to', url);
+  const url = await route(
+    { after: 'parent1', accountId, parent1Email },
+    api
+  );
+  console.log('[Pré-inscription] redirecting to', url);
 
-    window.location.href = url;
-  });
+  window.location.href = url;
 });
 
 async function route(params, api) {

--- a/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.webpage.copy.html
+++ b/Preinscription-moser/web-pages/Accueil/Accueil.fr-FR.webpage.copy.html
@@ -1,14 +1,11 @@
 
 <form id="start-form">
-  <div>
-    <label for="accountId">Identifiant du compte</label>
-    <input type="text" id="accountId" required />
-  </div>
-  <div>
-    <label for="parent1Email">Email du Parent 1</label>
-    <input type="email" id="parent1Email" required />
-  </div>
-  <button type="submit">Commencer la pré‑inscription</button>
+  <input
+    type="hidden"
+    id="accountId"
+    value="{{ user.parentcustomerid.id }}"
+  />
+  <input type="hidden" id="parent1Email" value="{{ user.email }}" />
 </form>
 
 <script src="Accueil.fr-FR.customjs.js"></script>


### PR DESCRIPTION
## Summary
- Pre-populate account and parent email from Liquid in Accueil page
- Route users automatically by reading hidden fields via JavaScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af25d0e4b883309d51ce84ce7a870c